### PR TITLE
Fix building 18.01.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+FROM centos/devtoolset-6-toolchain-centos7:latest
+
+LABEL \
+  description="Externpro Centos 7 Development Container" \
+  name="externpro-dev"
+
+USER 0
+RUN set -eux; \
+  yum --assumeyes --quiet update; \
+  yum install --assumeyes \
+    epel-release \
+    # This repository gives us more modern versions of some software, such as Git.
+    https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm; \
+  yum install --assumeyes \
+    cmake3 \
+    git \
+    gtk2-devel \
+    make \
+    mesa-libGL-devel \
+    mesa-libGLU-devel \
+    ncurses-devel \
+    ninja-build \
+    wget; \
+  yum --assumeyes --quiet clean all; \
+  ln -s cmake3 /usr/bin/cmake; \
+  ln -s ctest3 /usr/bin/ctest; \
+  ln -s cpack3 /usr/bin/cpack
+
+RUN set -eux; \
+  wget \
+    https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash; \
+  wget \
+    https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh; \
+  chmod 744 git-completion.bash git-prompt.sh; \
+  echo ". ~/git-completion.bash" >> ${HOME}/.bashrc; \
+  echo ". ~/git-prompt.sh" >> ${HOME}/.bashrc; \
+  echo "alias ls='ls --color=auto'" >> ${HOME}/.bashrc
+
+RUN echo "PS1='\n\[\e[01;39m\]externpro-dev \[\e[01;35m\]\w\[\e[01;36m\]\$(__git_ps1)\[\e[0m\]\n'" >> ${HOME}/.bashrc
+
+CMD ["/bin/bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,7 @@ RUN set -eux; \
     mesa-libGLU-devel \
     ncurses-devel \
     ninja-build \
+    python-devel \
     wget; \
   yum --assumeyes --quiet clean all; \
   ln -s cmake3 /usr/bin/cmake; \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Externpro development container",
+  "build": {
+    "dockerfile": "Dockerfile",
+  },
+  "extensions": [
+    "ms-azuretools.vscode-docker",
+    "DavidAnson.vscode-markdownlint",
+    "eamodio.gitlens",
+    "Gruntfuggly.todo-tree",
+    "IBM.output-colorizer",
+    "mhutchie.git-graph",
+    "ms-vscode.cmake-tools",
+    "ms-vscode.cpptools",
+    "streetsidesoftware.code-spell-checker",
+    "twxs.cmake",
+  ],
+  "settings": {
+    "cmake.configureArgs": [
+      "-DXP_STEP:STRING=build"
+    ],
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/../build,target=/workspaces/build,type=bind,consistency=delegated",
+    "source=${localWorkspaceFolder}/../_bldpkgs,target=/workspaces/_bldpkgs,type=bind,consistency=delegated",
+  ]
+}

--- a/building.md
+++ b/building.md
@@ -1,0 +1,84 @@
+# Building externpro
+
+⚠️ Only 18.08.5 is tested by the maintainers.
+
+This document describes the process for building externpro.
+First, it provides the steps to manually build the software.
+Then, it details how you can [Visual Studio Code](https://code.visualstudio.com/) and a development container to make the process a bit easier.
+
+## Manual Build Process
+
+Externpro uses CMake to generate a build system.
+Some dependencies must be installed on your system.
+See [.devcontainer/Dockerfile](.devcontainer/Dockerfile) for the packages you need to install.
+They are listed in the `yum install` command.
+
+After you install the necessary tools and dependencies, you just need to run CMake two times.
+The first run configures the build system and the second builds the software.
+After the software is built, run CPack to generate the package.
+
+```bash
+cmake -D XP_STEP=build path/to/repository
+cmake --build . --parallel $(nproc)
+cpack
+```
+
+That's it.
+More details can be found in the [readme file](README.md).
+
+## Using VS Code and the Development Container
+
+This fork provides a [Dockerfile](.devcontainer/Dockerfile) and [devcontainer.json](.devcontainer/devcontainer.json) file.
+You can use these with Visual Studio Code for remote container development.
+This document will get you started.
+
+By default, the container mounts directories from your host filesystem:
+
+```text
+Host               Container
+-----------------------------------
+<parent>/          /workspaces/
+  <repository>/      <repository>/
+  _bldpkgs/          _bldpkgs/
+  build/             build/
+```
+
+This serves two purposes.
+First, files written by the build process to *\_bldpkgs/* and *build/* persist on the host.
+Second, assuming *parent/* is not on the system partition, this avoids writing excessive data to the system partition as would occur without the mounts.
+These are three individual mounts, so nothing else in *parent/* on the host is mounted into the container.
+
+### Starting the Container
+
+First, you need to install the relevant tools: Docker, VS Code, and the Remote Containers extension.
+Next, open the repository in VS Code.
+Use the VS Code command palette to run `Remote-Containers: Rebuild and Reopen in Container`.
+
+### Configuring the CMake Project
+
+After the container is open, use VS Code to configure the project.
+In the command palette, run `CMake: Configure`.
+
+The default configuration sets the CMake variable `XP_STEP` to *build*.
+The build step will then download, unpack, patch, and build all the projects.
+To use a different step, you must run CMake on the command line, or change the `cmake.configureArgs` VS Code setting.
+
+### Building the Software
+
+After the CMake project is configured, use the `CMake: Build` command in VS Code to build the project.
+The normal VS Coe CMake interface can be used, such as selecting a specific target to build.
+
+### Creating the Package
+
+After the software is all built, run CPack to build the package.
+This must be done manually; the CMake extension for VS Code does not support CPack.
+Open a terminal and change to the build directory.
+Then run CPack:
+
+```bash
+cpack
+```
+
+### More Reading
+
+- [VS Code Remote Development](https://code.visualstudio.com/docs/remote/remote-overview)

--- a/building.md
+++ b/building.md
@@ -47,6 +47,7 @@ This serves two purposes.
 First, files written by the build process to *\_bldpkgs/* and *build/* persist on the host.
 Second, assuming *parent/* is not on the system partition, this avoids writing excessive data to the system partition as would occur without the mounts.
 These are three individual mounts, so nothing else in *parent/* on the host is mounted into the container.
+These directories must already exist on the host; if they don't, the container will fail to start.
 
 ### Starting the Container
 

--- a/projects/bzip2.cmake
+++ b/projects/bzip2.cmake
@@ -13,8 +13,8 @@ set(PRO_BZIP2
   GIT_UPSTREAM git://github.com/LuaDist/bzip2.git
   GIT_TAG xp${VER} # what to 'git checkout'
   GIT_REF v${VER} # create patch from this tag to 'git checkout'
-  DLURL http://www.bzip.org/${VER}/bzip2-${VER}.tar.gz
-  DLMD5 00b516f4704d4a7cb50a1d97e6e8e15b
+  DLURL https://github.com/smanders/bzip2/archive/v${VER}.tar.gz
+  DLMD5 768128c6df06b779256cf93149e0cae7
   PATCH ${PATCH_DIR}/bzip2.patch
   DIFF ${REPO}/compare/
   )

--- a/projects/eigen.cmake
+++ b/projects/eigen.cmake
@@ -8,8 +8,8 @@ set(PRO_EIGEN
   DESC "C++ template library for linear algebra"
   REPO "repo" https://bitbucket.org/eigen/eigen "eigen hg repo on bitbucket"
   VER ${VER}
-  DLURL http://bitbucket.org/eigen/eigen/get/${VER}.tar.bz2
-  DLMD5 cc1bacbad97558b97da6b77c9644f184
+  DLURL https://gitlab.com/libeigen/eigen/-/archive/${VER}/eigen-${VER}.tar.bz2
+  DLMD5 efad2bd915ca85c8de5b7e095c64ca2b
   DLNAME eigen-${VER}.tar.bz2
   )
 ########################################

--- a/projects/geotranz.cmake
+++ b/projects/geotranz.cmake
@@ -4,7 +4,7 @@
 xpProOption(geotranz)
 set(VER 2.4.2)
 set(REPO https://github.com/smanders/geotranz)
-set(DLCSV ftp://downloads.osgeo.org/pub/geotiff/tables)
+set(DLCSV https://download.osgeo.org/geotiff/tables)
 set(DLDIR data)
 set(PRO_GEOTRANZ
   NAME geotranz
@@ -18,7 +18,7 @@ set(PRO_GEOTRANZ
   GIT_REF v${VER} # create patch from this tag to 'git checkout'
   PATCH ${PATCH_DIR}/geotranz.patch
   DIFF ${REPO}/compare/
-  DLURL http://geotranz.sourcearchive.com/downloads/${VER}/geotranz_${VER}.orig.tar.gz
+  DLURL https://github.com/smanders/externpro/releases/download/18.04.1/geotranz_${VER}.orig.tar.gz
   DLMD5 1d370d5b0daed2a541a9aa14bd3172a8
   DLMD5_01 48cffaef0651db24c43b8afaee7fbeaf DLDIR_01 ${DLDIR} DLURL_01 ${DLCSV}/README
   DLMD5_02 8e3cb60e597f9bd36d0639406a4cf40a DLDIR_02 ${DLDIR} DLURL_02 ${DLCSV}/compd_cs.csv


### PR DESCRIPTION
- Since January 2018, Eigen moved from Bitbucket to Gitlab. This pull request fixes the download URL and MD5 for Eigen.
- Geotranz and the geotiff data moved, too.
- Bzip2 also moved.
- I added a Dockerfile and devcontainer files for building externpro in a development container.

@swflb, we need this prior to getting a devcontainer to work for ovsrpro.